### PR TITLE
  Fix PNG text rendering by setting defaultFontFamily

### DIFF
--- a/src/png/converter.js
+++ b/src/png/converter.js
@@ -25,6 +25,7 @@ export function convertSvgToPng(svgString, options = {}) {
     font: {
       fontBuffers: [fontBuffer],
       loadSystemFonts: false,
+      defaultFontFamily: 'Noto Sans',
     },
     fitTo: {
       mode: 'zoom',


### PR DESCRIPTION
  - Add defaultFontFamily: 'Noto Sans' to resvg options
  - Ensures text renders when SVG doesn't specify font-family