### PR TITLE
Fix font loading for Vercel serverless environment

### DIFF
--- a/src/png/converter.js
+++ b/src/png/converter.js
@@ -1,18 +1,26 @@
 import { Resvg } from '@resvg/resvg-js';
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+// Font paths to try (Vercel serverless uses process.cwd(), local uses __dirname)
+// See: https://vercel.com/kb/guide/how-can-i-use-files-in-serverless-functions
+const fontPaths = [
+  join(process.cwd(), 'src', 'png', 'fonts', 'NotoSans-Regular.ttf'),
+];
 
-// Load font file once at module initialization
-const fontPath = join(__dirname, 'fonts', 'NotoSans-Regular.ttf');
 let fontData = null;
 
 function loadFont() {
   if (!fontData) {
-    fontData = readFileSync(fontPath);
+    for (const fontPath of fontPaths) {
+      if (existsSync(fontPath)) {
+        fontData = readFileSync(fontPath);
+        break;
+      }
+    }
+    if (!fontData) {
+      console.error('Font file not found in:', fontPaths);
+    }
   }
   return fontData;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,10 @@
       "destination": "/api/graph?demo=true",
       "permanent": false
     }
-  ]
+  ],
+  "functions": {
+    "api/graph.js": {
+      "includeFiles": "src/png/fonts/**"
+    }
+  }
 }


### PR DESCRIPTION
- Use process.cwd() instead of __dirname for font path resolution
- Add includeFiles config in vercel.json to bundle font files

See: https://vercel.com/kb/guide/how-can-i-use-files-in-serverless-functions