### PR TITLE
Fix Vercel font loading with loadSystemFonts: false

### DIFF
--- a/src/png/converter.js
+++ b/src/png/converter.js
@@ -29,6 +29,7 @@ export function convertSvgToPng(svg, scale = 2) {
   const resvg = new Resvg(svg, {
     font: {
       fontBuffers: [font],
+      loadSystemFonts: false,
       defaultFontFamily: 'Noto Sans',
     },
     fitTo: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,9 @@
 {
+  "functions": {
+    "api/**/*.js": {
+      "includeFiles": "src/png/fonts/**"
+    }
+  },
   "redirects": [
     {
       "source": "/",


### PR DESCRIPTION
## Summary
- Add `loadSystemFonts: false` to prevent resvg from looking for non-existent system fonts in Vercel serverless environment
- Add `includeFiles` in vercel.json to ensure font files are bundled with the function

## Changes
- `src/png/converter.js`: Added `loadSystemFonts: false` option
- `vercel.json`: Added `functions.includeFiles` configuration

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Access `/api/graph?demo=true&format=png`
- [ ] Verify text renders correctly in PNG output

🤖 Generated with [Claude Code](https://claude.com/claude-code)