### PR TITLE
feat: add preset colors for major OSS organizations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -34,11 +34,24 @@ Vercelのダッシュボードで以下の環境変数を設定:
 | パラメータ | 説明 | デフォルト | 例 |
 |-----------|------|-----------|-----|
 | `username` | GitHubユーザー名 | `yujiteshima` | `yujiteshima` |
-| `orgs` | 組織設定 (カンマ区切り) | rails, hotwired | `rails:CC0000:Rails,hotwired:1a1a1a:Hotwire` |
+| `orgs` | 組織設定 (カンマ区切り) | rails, hotwired | `rails,vuejs,kubernetes` |
 | `months` | 表示期間 (1-12) | `6` | `3`, `6`, `12` |
+| `format` | 出力形式 | `svg` | `svg`, `png` |
 | `demo` | デモモード | `false` | `true` |
 
 ### orgs パラメータの形式
+
+**プリセットカラー（推奨）** - 組織名を指定するだけ:
+
+```
+?orgs=rails,vuejs,kubernetes
+```
+
+対応プリセット: `vercel`, `vuejs`, `react`, `angular`, `kubernetes`, `docker`, `rails`, `django`, `fastapi`, `nodejs`, `rust-lang`, `golang`, `tensorflow`, `pytorch`, `opencv`, `cupy`, `htmx` など
+
+エイリアスも使用可能: `k8s` → kubernetes, `go` → golang, `vue` → vuejs など
+
+**カスタムカラー** - 色とラベルを手動指定:
 
 ```
 組織名:色(6桁HEX):ラベル
@@ -49,9 +62,21 @@ Vercelのダッシュボードで以下の環境変数を設定:
 - `hotwired:1a1a1a:Hotwire` - hotwiredの貢献を黒色で表示
 - `honojs:E36002:Hono` - honojsの貢献をオレンジで表示
 
+**混在** - プリセットとカスタムの組み合わせ:
+
+```
+?orgs=rails,vuejs,custom:FFFFFF:My Org
+```
+
 ## カスタマイズ例
 
-### Rails + Hotwire + Hono
+### プリセットカラーを使用（簡単）
+
+```markdown
+![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails,vuejs,kubernetes&months=6)
+```
+
+### Rails + Hotwire + Hono（カスタムカラー）
 
 ```markdown
 ![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails:CC0000:Rails,hotwired:1a1a1a:Hotwire,honojs:E36002:Hono&months=6)
@@ -60,13 +85,27 @@ Vercelのダッシュボードで以下の環境変数を設定:
 ### 3ヶ月表示
 
 ```markdown
-![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails:CC0000:Rails&months=3)
+![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails&months=3)
+```
+
+### PNG出力（SNS共有用）
+
+```markdown
+![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails,vuejs&format=png)
+```
+
+### OGPカード（X/Twitterリンクプレビュー用）
+
+`/api/card` エンドポイントでOGPメタタグを取得:
+
+```
+https://your-app.vercel.app/api/card?username=yujiteshima&orgs=rails,vuejs
 ```
 
 ### デモモード（トークンなしで動作確認）
 
 ```markdown
-![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&demo=true)
+![OSS Contributions](https://your-app.vercel.app/api/graph?demo=true)
 ```
 
 ## ローカル開発

--- a/README.md
+++ b/README.md
@@ -33,11 +33,24 @@ Configure the following environment variable in the Vercel dashboard:
 | Parameter | Description | Default | Example |
 |-----------|-------------|---------|---------|
 | `username` | GitHub username | `yujiteshima` | `yujiteshima` |
-| `orgs` | Organization settings (comma-separated) | rails, hotwired | `rails:CC0000:Rails,hotwired:1a1a1a:Hotwire` |
+| `orgs` | Organization settings (comma-separated) | rails, hotwired | `rails,vuejs,kubernetes` |
 | `months` | Display period (1-12) | `6` | `3`, `6`, `12` |
+| `format` | Output format | `svg` | `svg`, `png` |
 | `demo` | Demo mode | `false` | `true` |
 
 ### orgs Parameter Format
+
+**Preset colors (Recommended)** - Just specify organization names:
+
+```
+?orgs=rails,vuejs,kubernetes
+```
+
+Supported presets include: `vercel`, `vuejs`, `react`, `angular`, `kubernetes`, `docker`, `rails`, `django`, `fastapi`, `nodejs`, `rust-lang`, `golang`, `tensorflow`, `pytorch`, `opencv`, `cupy`, `htmx`, and more.
+
+Aliases are also supported: `k8s` → kubernetes, `go` → golang, `vue` → vuejs, etc.
+
+**Custom colors** - Specify color and label manually:
 
 ```
 organization:color(6-digit HEX):label
@@ -48,9 +61,21 @@ Examples:
 - `hotwired:1a1a1a:Hotwire` - Display Hotwire contributions in black
 - `honojs:E36002:Hono` - Display Hono contributions in orange
 
+**Mixed** - Combine presets and custom:
+
+```
+?orgs=rails,vuejs,custom:FFFFFF:My Org
+```
+
 ## Customization Examples
 
-### Rails + Hotwire + Hono
+### Using Preset Colors (Simple)
+
+```markdown
+![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails,vuejs,kubernetes&months=6)
+```
+
+### Rails + Hotwire + Hono (Custom Colors)
 
 ```markdown
 ![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails:CC0000:Rails,hotwired:1a1a1a:Hotwire,honojs:E36002:Hono&months=6)
@@ -59,13 +84,27 @@ Examples:
 ### 3-Month Display
 
 ```markdown
-![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails:CC0000:Rails&months=3)
+![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails&months=3)
+```
+
+### PNG Output (for social media sharing)
+
+```markdown
+![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&orgs=rails,vuejs&format=png)
+```
+
+### OGP Card (for X/Twitter link preview)
+
+Use `/api/card` endpoint for OGP meta tags:
+
+```
+https://your-app.vercel.app/api/card?username=yujiteshima&orgs=rails,vuejs
 ```
 
 ### Demo Mode (Test without token)
 
 ```markdown
-![OSS Contributions](https://your-app.vercel.app/api/graph?username=yujiteshima&demo=true)
+![OSS Contributions](https://your-app.vercel.app/api/graph?demo=true)
 ```
 
 ## Local Development

--- a/src/presets/organizations.js
+++ b/src/presets/organizations.js
@@ -1,0 +1,127 @@
+// Preset colors for major OSS organizations
+// Colors sourced from official brand guidelines and logos
+
+export const ORGANIZATION_PRESETS = {
+  // JavaScript / Frontend
+  vercel: { color: '#000000', label: 'Vercel' },
+  facebook: { color: '#0081FB', label: 'Facebook' },
+  react: { color: '#61DAFB', label: 'React', org: 'facebook' },
+  vuejs: { color: '#42B883', label: 'Vue.js' },
+  angular: { color: '#DD0031', label: 'Angular' },
+  sveltejs: { color: '#FF3E00', label: 'Svelte' },
+  nodejs: { color: '#339933', label: 'Node.js' },
+  denoland: { color: '#000000', label: 'Deno' },
+  htmx: { color: '#3366CC', label: 'htmx' },
+  'bigskysoftware': { color: '#3366CC', label: 'htmx' },
+
+  // Backend / Infrastructure
+  rails: { color: '#CC0000', label: 'Rails' },
+  django: { color: '#092E20', label: 'Django' },
+  laravel: { color: '#FF2D20', label: 'Laravel' },
+  spring: { color: '#6DB33F', label: 'Spring' },
+  'spring-projects': { color: '#6DB33F', label: 'Spring' },
+  fastapi: { color: '#009688', label: 'FastAPI' },
+  tiangolo: { color: '#009688', label: 'FastAPI' },
+
+  // Cloud / DevOps
+  kubernetes: { color: '#326CE5', label: 'Kubernetes' },
+  docker: { color: '#2496ED', label: 'Docker' },
+  hashicorp: { color: '#000000', label: 'HashiCorp' },
+  terraform: { color: '#7B42BC', label: 'Terraform', org: 'hashicorp' },
+
+  // Languages
+  'rust-lang': { color: '#DEA584', label: 'Rust' },
+  golang: { color: '#00ADD8', label: 'Go' },
+  python: { color: '#3776AB', label: 'Python' },
+  ruby: { color: '#CC342D', label: 'Ruby' },
+  'ruby-lang': { color: '#CC342D', label: 'Ruby' },
+  elixir: { color: '#4B275F', label: 'Elixir' },
+  'elixir-lang': { color: '#4B275F', label: 'Elixir' },
+
+  // Big Tech
+  microsoft: { color: '#00A4EF', label: 'Microsoft' },
+  google: { color: '#4285F4', label: 'Google' },
+  aws: { color: '#FF9900', label: 'AWS' },
+  apple: { color: '#000000', label: 'Apple' },
+
+  // AI / ML
+  tensorflow: { color: '#FF6F00', label: 'TensorFlow' },
+  pytorch: { color: '#EE4C2C', label: 'PyTorch' },
+  huggingface: { color: '#FFD21E', label: 'Hugging Face' },
+  openai: { color: '#412991', label: 'OpenAI' },
+
+  // Scientific Computing / Computer Vision
+  cupy: { color: '#46C0B6', label: 'CuPy' },
+  opencv: { color: '#5C3EE8', label: 'OpenCV' },
+  numpy: { color: '#013243', label: 'NumPy' },
+  scipy: { color: '#8CAAE6', label: 'SciPy' },
+
+  // Database
+  postgresql: { color: '#4169E1', label: 'PostgreSQL' },
+  mongodb: { color: '#47A248', label: 'MongoDB' },
+  redis: { color: '#DC382D', label: 'Redis' },
+
+  // Tools
+  github: { color: '#181717', label: 'GitHub' },
+  gitlab: { color: '#FC6D26', label: 'GitLab' },
+  jetbrains: { color: '#000000', label: 'JetBrains' },
+
+  // Hotwire ecosystem
+  hotwired: { color: '#1a1a1a', label: 'Hotwire' },
+};
+
+// Alias mappings (alternative names pointing to the same preset)
+export const ORGANIZATION_ALIASES = {
+  fb: 'facebook',
+  reactjs: 'react',
+  vue: 'vuejs',
+  node: 'nodejs',
+  deno: 'denoland',
+  rust: 'rust-lang',
+  go: 'golang',
+  py: 'python',
+  rb: 'ruby',
+  k8s: 'kubernetes',
+  tf: 'terraform',
+  hf: 'huggingface',
+  pg: 'postgresql',
+  mongo: 'mongodb',
+  cv: 'opencv',
+  'opencv-python': 'opencv',
+};
+
+/**
+ * Get preset configuration for an organization
+ * @param {string} name - Organization name or alias
+ * @returns {{ color: string, label: string, org?: string } | null}
+ */
+export function getOrganizationPreset(name) {
+  const normalizedName = name.toLowerCase();
+
+  // Check aliases first
+  const aliasTarget = ORGANIZATION_ALIASES[normalizedName];
+  if (aliasTarget) {
+    return ORGANIZATION_PRESETS[aliasTarget] || null;
+  }
+
+  return ORGANIZATION_PRESETS[normalizedName] || null;
+}
+
+/**
+ * Get the actual GitHub organization name for a preset
+ * Some presets (like 'react') map to a different org ('facebook')
+ * @param {string} name - Preset name
+ * @returns {string} GitHub organization name
+ */
+export function getOrganizationName(name) {
+  const preset = getOrganizationPreset(name);
+  if (preset?.org) {
+    return preset.org;
+  }
+
+  // Resolve alias to canonical name
+  const normalizedName = name.toLowerCase();
+  const aliasTarget = ORGANIZATION_ALIASES[normalizedName];
+
+  return aliasTarget || normalizedName;
+}

--- a/tests/presets/organizations.test.js
+++ b/tests/presets/organizations.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ORGANIZATION_PRESETS,
+  ORGANIZATION_ALIASES,
+  getOrganizationPreset,
+  getOrganizationName,
+} from '../../src/presets/organizations.js';
+
+describe('ORGANIZATION_PRESETS', () => {
+  it('contains expected major organizations', () => {
+    expect(ORGANIZATION_PRESETS.vercel).toBeDefined();
+    expect(ORGANIZATION_PRESETS.vuejs).toBeDefined();
+    expect(ORGANIZATION_PRESETS.kubernetes).toBeDefined();
+    expect(ORGANIZATION_PRESETS.rails).toBeDefined();
+  });
+
+  it('has valid color format for all presets', () => {
+    for (const [name, preset] of Object.entries(ORGANIZATION_PRESETS)) {
+      expect(preset.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      expect(preset.label).toBeTruthy();
+    }
+  });
+});
+
+describe('getOrganizationPreset', () => {
+  it('returns preset for known organization', () => {
+    const preset = getOrganizationPreset('vuejs');
+    expect(preset).toEqual({ color: '#42B883', label: 'Vue.js' });
+  });
+
+  it('returns preset for organization with org mapping', () => {
+    const preset = getOrganizationPreset('react');
+    expect(preset).toEqual({ color: '#61DAFB', label: 'React', org: 'facebook' });
+  });
+
+  it('returns null for unknown organization', () => {
+    const preset = getOrganizationPreset('unknown-org');
+    expect(preset).toBeNull();
+  });
+
+  it('resolves alias to preset', () => {
+    const preset = getOrganizationPreset('k8s');
+    expect(preset).toEqual({ color: '#326CE5', label: 'Kubernetes' });
+  });
+
+  it('handles case insensitivity', () => {
+    expect(getOrganizationPreset('VueJS')).toEqual({ color: '#42B883', label: 'Vue.js' });
+    expect(getOrganizationPreset('KUBERNETES')).toEqual({ color: '#326CE5', label: 'Kubernetes' });
+  });
+});
+
+describe('getOrganizationName', () => {
+  it('returns same name for organization without mapping', () => {
+    expect(getOrganizationName('vuejs')).toBe('vuejs');
+    expect(getOrganizationName('kubernetes')).toBe('kubernetes');
+  });
+
+  it('returns mapped org name for presets with org property', () => {
+    expect(getOrganizationName('react')).toBe('facebook');
+    expect(getOrganizationName('terraform')).toBe('hashicorp');
+  });
+
+  it('resolves alias to canonical name', () => {
+    expect(getOrganizationName('k8s')).toBe('kubernetes');
+    expect(getOrganizationName('vue')).toBe('vuejs');
+    expect(getOrganizationName('go')).toBe('golang');
+  });
+
+  it('returns input for unknown organization', () => {
+    expect(getOrganizationName('unknown-org')).toBe('unknown-org');
+  });
+
+  it('handles case insensitivity', () => {
+    expect(getOrganizationName('K8S')).toBe('kubernetes');
+    expect(getOrganizationName('React')).toBe('facebook');
+  });
+});
+
+describe('ORGANIZATION_ALIASES', () => {
+  it('contains common aliases', () => {
+    expect(ORGANIZATION_ALIASES.k8s).toBe('kubernetes');
+    expect(ORGANIZATION_ALIASES.vue).toBe('vuejs');
+    expect(ORGANIZATION_ALIASES.go).toBe('golang');
+    expect(ORGANIZATION_ALIASES.rust).toBe('rust-lang');
+  });
+});

--- a/tests/utils/params.test.js
+++ b/tests/utils/params.test.js
@@ -78,11 +78,54 @@ describe('parseOrgs', () => {
     ]);
   });
 
-  it('handles org with only name', () => {
+  it('handles org with only name (no preset)', () => {
+    const result = parseOrgs('unknown-org');
+    expect(result).toEqual([
+      { name: 'unknown-org', color: '#39d353', label: 'unknown-org' },
+    ]);
+  });
+
+  it('resolves preset color for known organization', () => {
     const result = parseOrgs('vuejs');
     expect(result).toEqual([
-      { name: 'vuejs', color: '#39d353', label: 'vuejs' },
+      { name: 'vuejs', color: '#42B883', label: 'Vue.js' },
     ]);
+  });
+
+  it('resolves preset color for kubernetes', () => {
+    const result = parseOrgs('kubernetes');
+    expect(result).toEqual([
+      { name: 'kubernetes', color: '#326CE5', label: 'Kubernetes' },
+    ]);
+  });
+
+  it('resolves alias to preset', () => {
+    const result = parseOrgs('k8s');
+    expect(result).toEqual([
+      { name: 'kubernetes', color: '#326CE5', label: 'Kubernetes' },
+    ]);
+  });
+
+  it('resolves react alias to facebook org', () => {
+    const result = parseOrgs('react');
+    expect(result).toEqual([
+      { name: 'facebook', color: '#61DAFB', label: 'React' },
+    ]);
+  });
+
+  it('allows explicit color to override preset', () => {
+    const result = parseOrgs('vuejs:FF0000:Custom Vue');
+    expect(result).toEqual([
+      { name: 'vuejs', color: '#FF0000', label: 'Custom Vue' },
+    ]);
+  });
+
+  it('supports mixed preset and explicit orgs', () => {
+    const result = parseOrgs('rails,custom:FFFFFF:Custom Org,kubernetes');
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ name: 'rails', color: '#CC0000', label: 'Rails' });
+    expect(result[1]).toEqual({ name: 'custom', color: '#FFFFFF', label: 'Custom Org' });
+    expect(result[2]).toEqual({ name: 'kubernetes', color: '#326CE5', label: 'Kubernetes' });
   });
 
   it('trims whitespace from values', () => {


### PR DESCRIPTION
Add automatic color resolution for 40+ OSS organizations including:
- Frontend: vercel, vuejs, react, angular, sveltejs, nodejs, htmx
- Backend: rails, django, laravel, fastapi
- Cloud/DevOps: kubernetes, docker, hashicorp
- Languages: rust-lang, golang, python, ruby, elixir
- AI/ML: tensorflow, pytorch, huggingface, opencv, cupy

Features:
- Preset-only format: ?orgs=rails,vuejs,kubernetes
- Aliases support: k8s -> kubernetes, go -> golang, vue -> vuejs
- Org mapping: react -> facebook
- Explicit override: ?orgs=vuejs:FF0000:Custom
- Mixed format: ?orgs=rails,custom:FFFFFF:My Org

Also update README with preset colors and PNG/OGP documentation.