### PR TITLE
fix: map htmx preset to bigskysoftware organization

### DIFF
--- a/src/presets/organizations.js
+++ b/src/presets/organizations.js
@@ -11,7 +11,7 @@ export const ORGANIZATION_PRESETS = {
   sveltejs: { color: '#FF3E00', label: 'Svelte' },
   nodejs: { color: '#339933', label: 'Node.js' },
   denoland: { color: '#000000', label: 'Deno' },
-  htmx: { color: '#3366CC', label: 'htmx' },
+  htmx: { color: '#3366CC', label: 'htmx', org: 'bigskysoftware' },
   'bigskysoftware': { color: '#3366CC', label: 'htmx' },
 
   // Backend / Infrastructure

--- a/tests/presets/organizations.test.js
+++ b/tests/presets/organizations.test.js
@@ -58,6 +58,7 @@ describe('getOrganizationName', () => {
   it('returns mapped org name for presets with org property', () => {
     expect(getOrganizationName('react')).toBe('facebook');
     expect(getOrganizationName('terraform')).toBe('hashicorp');
+    expect(getOrganizationName('htmx')).toBe('bigskysoftware');
   });
 
   it('resolves alias to canonical name', () => {

--- a/tests/utils/params.test.js
+++ b/tests/utils/params.test.js
@@ -113,6 +113,13 @@ describe('parseOrgs', () => {
     ]);
   });
 
+  it('resolves htmx to bigskysoftware org', () => {
+    const result = parseOrgs('htmx');
+    expect(result).toEqual([
+      { name: 'bigskysoftware', color: '#3366CC', label: 'htmx' },
+    ]);
+  });
+
   it('allows explicit color to override preset', () => {
     const result = parseOrgs('vuejs:FF0000:Custom Vue');
     expect(result).toEqual([


### PR DESCRIPTION
htmx project is maintained under the bigskysoftware GitHub organization. Without the org mapping, using ?orgs=htmx would query a non-existent 'htmx' organization, resulting in no contribution data being displayed.

Added org: 'bigskysoftware' property to htmx preset, similar to how react maps to facebook and terraform maps to hashicorp.